### PR TITLE
add in string literals

### DIFF
--- a/CoreWLANController.m
+++ b/CoreWLANController.m
@@ -45,10 +45,10 @@
 			phyModeStr = @"802.11n";
 			break;
 		case kCWPHYMode11ac:
-			phyModeStr = "802.11ac";
+			phyModeStr = @"802.11ac";
 			break;
 		default:
-			phyModeStr = "?unknown mode?";
+			phyModeStr = @"?unknown mode?";
 			break;
 	}
 	return phyModeStr;


### PR DESCRIPTION
The current code is not buildable out of the box because of these missing "`@`" characters (for string literals). 

This PR will allow anyone to be able to clone/pull and then build again.